### PR TITLE
docker_action.yml add install texlive academicians

### DIFF
--- a/.github/workflows/docker_action.yaml
+++ b/.github/workflows/docker_action.yaml
@@ -29,6 +29,7 @@ jobs:
           sudo apt-get install -y texlive-latex-recommended
           sudo apt-get install -y texlive-xetex
           sudo apt-get install -y texlive-fonts-extra
+          sudo apt-get install -y texlive-academicons
      - name: render the curriculum vitae
        run: |
          Rscript -e "print(getwd())"


### PR DESCRIPTION
This is because the orcid id in the .Rmd yaml header requires academicians. I'm not sure if this is the correct way to do it, but let's see.